### PR TITLE
chore: suppress brownie warning

### DIFF
--- a/yearn_treasury/__init__.py
+++ b/yearn_treasury/__init__.py
@@ -1,8 +1,18 @@
+import warnings
+
 from yearn_treasury import budget
 from yearn_treasury._db import prepare_db
 
 
 prepare_db()
+
+
+warnings.filterwarnings(
+    "ignore",
+    message=".Event log does not contain enough topics for the given ABI.",
+    category=UserWarning,
+    module="brownie.network.event"
+)
 
 
 __all__ = ["budget"]


### PR DESCRIPTION
"Event log does not contain enough topics for the given ABI."