### PR TITLE
fix: dont compile curve sort rules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ else:
             "yearn_treasury/rules/expense",
             # "yearn_treasury/rules/ignore",
             "yearn_treasury/rules/ignore/swaps/conversion_factory.py",
-            "yearn_treasury/rules/ignore/swaps/curve.py",
+            # "yearn_treasury/rules/ignore/swaps/curve.py",  enable with brownie 1.22.0
             "yearn_treasury/rules/ignore/swaps/gearbox.py",
             "yearn_treasury/rules/ignore/swaps/iearn.py",
             "yearn_treasury/rules/ignore/swaps/otc.py",


### PR DESCRIPTION
wait until brownie 1.22 with the typing fixes