### PR TITLE
docs: add AGENTS mypy config rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,5 +16,6 @@ All agents must follow these rules:
 10) If the repo uses mypyc, verify tests run against compiled extensions (not interpreted Python) and note how you confirmed.
 11) If the branch you're assigned to work on tracks a remote (ie origin/master or upstream/awesome-feature), fetch and pull from that remote before you begin so you're working from the latest commits (eg `git fetch <remote> && git pull <remote> <branch>`).
 12) Maximize the use of caching in GitHub workflow files to minimize run duration.
+13) All mypy configuration (flags, overrides, per-module ignores, and file targets) should go in pyproject.toml. Do not split config across CLI args, mypy.ini, setup.cfg, or workflow steps.
 
 Reference: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
Summary
- Add the AGENTS rule centralizing mypy configuration in pyproject.toml.

Rationale
- Keep type-checking configuration consistent and avoid drift across tooling.

Details
- Update `AGENTS.md` only.