### PR TITLE
chore(cicd): centralize mypy config in pyproject

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ docs:
 	poetry run sphinx-apidoc -o ./docs/source ./yearn_treasury
 
 mypy:
-	poetry run mypy .
+	poetry run mypy
 
 # Update the TaskStart hook submodule and commit the change
 hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ myst-parser = "*"
 
 [tool.mypy]
 exclude = ["build/","cache/","env/", "tests/", "setup.py"]
+files = ["."]
 ignore_missing_imports = true
 check_untyped_defs = true
 


### PR DESCRIPTION
## Summary
- Move mypy file targets into `pyproject.toml`
- Remove inline mypy target from the Makefile

## Rationale
- Centralizing mypy config avoids drift and ensures a single source of truth.

## Details
- `pyproject.toml`
- `Makefile`

## Testing
- Command(s) run: none (skipped per user instruction)
- Result: SKIPPED
