### PR TITLE
fix(cicd): scope docs workflow to relevant changes

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,11 +4,23 @@ on:
   push:
     branches:
       - master
+    paths:
+      - ./.github/workflows/docs.yaml
+      - docs/**
+      - '**.py'
+      - pyproject.toml
+      - poetry.lock
+      - Makefile
+      - README.md
   pull_request:
     paths:
       - ./.github/workflows/docs.yaml
+      - docs/**
+      - '**.py'
       - pyproject.toml
       - poetry.lock
+      - Makefile
+      - README.md
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Summary:
- Add path filters to the docs workflow for push and pull_request triggers.

Rationale:
- Limit docs builds to documentation, code, and config changes to reduce unnecessary CI runs.

Details:
- Include docs, Python sources, and key config files in the workflow path filters.
- Tests: not run (per request).