### PR TITLE
fix: require grafana admin env and document auth defaults

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ This project defines dashboards using JSON definitions located in the [dao-treas
 
 1. **Access the Grafana UI**  
    - Open Grafana in your web browser.
-   - You can login to your local deployment as an administrator with username: `admin` and password: `admin`
+   - Set `GF_SECURITY_ADMIN_USER` and `GF_SECURITY_ADMIN_PASSWORD`, then login with those credentials.
   
 2. **Build Your Dashboard**  
    - Click on the **"+"** icon in the sidebar and choose **Dashboard**.
@@ -53,7 +53,7 @@ This project defines dashboards using JSON definitions located in the [dao-treas
 
 1. **Access the Existing Dashboard**  
    - Open Grafana in your web browser.
-   - Login to your local deployment as an administrator with username: `admin` and password: `admin`.
+   - Login to your local deployment using the Grafana admin credentials you set.
    - Navigate to the existing dashboard you wish to modify.
    - Open the dashboard and click **Edit** to modify panels, queries, or visual styles.
 

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ Run the treasury export tool:
 
 ```bash
 # For pip installations:
-yearn-treasury --network mainnet --interval 12h
+GF_SECURITY_ADMIN_USER=admin GF_SECURITY_ADMIN_PASSWORD=... yearn-treasury --network mainnet --interval 12h
 ```
 
 For local development (from source installation), use:
 ```bash
-poetry run yearn-treasury --network mainnet --interval 12h
+GF_SECURITY_ADMIN_USER=admin GF_SECURITY_ADMIN_PASSWORD=... poetry run yearn-treasury --network mainnet --interval 12h
 ```
 
 **CLI Options:**
@@ -48,8 +48,12 @@ poetry run yearn-treasury --network mainnet --interval 12h
 - `--renderer-port`: Set the port for the report rendering service (default: 8080)
 - `--victoria-port`: Set the port for the Victoria metrics reporting endpoint (default: 8430)
 
+**Grafana Auth:**
+- Requires `GF_SECURITY_ADMIN_USER` and `GF_SECURITY_ADMIN_PASSWORD`.
+- Optional anonymous access via `DAO_TREASURY_GRAFANA_ANON_ENABLED=true`.
+
 After running the command, the export script will run continuously until you close your terminal.
-To access the dashboard, open your browser and navigate to [http://localhost:3004](http://localhost:3004) for the [dao-treasury](https://github.com/BobTheBuidler/dao-treasury) dashboard.
+To access the dashboard, open your browser and navigate to [http://localhost:3004](http://localhost:3004) for the [dao-treasury](https://github.com/BobTheBuidler/dao-treasury) dashboard and log in with your Grafana admin credentials.
 
 Enjoy!
 

--- a/docs/transactions.rst
+++ b/docs/transactions.rst
@@ -3,6 +3,10 @@ Transactions Dashboard
 
 This dashboard provides a real-time view of the transactions in yearn-treasury's database, displaying columns such as timestamp, block, hash, token, addresses, and associated metadata (address nicknames, amount, price, and value in USD).
 
+Access Note:
+- Grafana requires admin credentials set via `GF_SECURITY_ADMIN_USER` and `GF_SECURITY_ADMIN_PASSWORD`.
+- Optional anonymous access can be enabled with `DAO_TREASURY_GRAFANA_ANON_ENABLED=true`.
+
 Key Features
 ------------
 

--- a/tests/test_grafana_env.py
+++ b/tests/test_grafana_env.py
@@ -1,0 +1,32 @@
+import pytest
+
+from yearn_treasury._grafana import require_grafana_admin_env
+
+
+def test_require_grafana_admin_env_missing_both(monkeypatch):
+    monkeypatch.delenv("GF_SECURITY_ADMIN_USER", raising=False)
+    monkeypatch.delenv("GF_SECURITY_ADMIN_PASSWORD", raising=False)
+    with pytest.raises(RuntimeError, match="GF_SECURITY_ADMIN_USER.*GF_SECURITY_ADMIN_PASSWORD"):
+        require_grafana_admin_env()
+
+
+def test_require_grafana_admin_env_missing_user(monkeypatch):
+    monkeypatch.delenv("GF_SECURITY_ADMIN_USER", raising=False)
+    monkeypatch.setenv("GF_SECURITY_ADMIN_PASSWORD", "secret")
+    with pytest.raises(RuntimeError, match="GF_SECURITY_ADMIN_USER"):
+        require_grafana_admin_env()
+
+
+def test_require_grafana_admin_env_missing_password(monkeypatch):
+    monkeypatch.setenv("GF_SECURITY_ADMIN_USER", "admin")
+    monkeypatch.delenv("GF_SECURITY_ADMIN_PASSWORD", raising=False)
+    with pytest.raises(RuntimeError, match="GF_SECURITY_ADMIN_PASSWORD"):
+        require_grafana_admin_env()
+
+
+def test_require_grafana_admin_env_success(monkeypatch):
+    monkeypatch.setenv("GF_SECURITY_ADMIN_USER", "admin")
+    monkeypatch.setenv("GF_SECURITY_ADMIN_PASSWORD", "secret")
+    user, password = require_grafana_admin_env()
+    assert user == "admin"
+    assert password == "secret"

--- a/yearn_treasury/_grafana.py
+++ b/yearn_treasury/_grafana.py
@@ -1,0 +1,24 @@
+"""Grafana environment validation for Yearn Treasury."""
+
+from __future__ import annotations
+
+import os
+
+
+def require_grafana_admin_env() -> tuple[str, str]:
+    """Return Grafana admin creds or raise a clear error if missing."""
+    missing: list[str] = []
+    admin_user = os.getenv("GF_SECURITY_ADMIN_USER")
+    admin_password = os.getenv("GF_SECURITY_ADMIN_PASSWORD")
+    if not admin_user:
+        missing.append("GF_SECURITY_ADMIN_USER")
+    if not admin_password:
+        missing.append("GF_SECURITY_ADMIN_PASSWORD")
+    if missing:
+        missing_list = ", ".join(missing)
+        raise RuntimeError(
+            "Grafana admin credentials are required. "
+            f"Missing environment variables: {missing_list}. "
+            "Set DAO_TREASURY_GRAFANA_ANON_ENABLED=true only if you want anonymous access."
+        )
+    return admin_user, admin_password

--- a/yearn_treasury/main.py
+++ b/yearn_treasury/main.py
@@ -11,7 +11,8 @@ Example:
 
     .. code-block:: bash
 
-        yearn-treasury run --network mainnet --interval 12h
+        GF_SECURITY_ADMIN_USER=admin GF_SECURITY_ADMIN_PASSWORD=... \\
+          yearn-treasury run --network mainnet --interval 12h
 
 CLI Options:
     --network         Brownie network identifier (default: mainnet)
@@ -22,6 +23,8 @@ CLI Options:
     --victoria-port   Port for the Victoria metrics endpoint (default: 8430)
     --start-renderer  Start the Grafana renderer container for dashboard image export
     --renderer-port   Port for the renderer service (default: 8080)
+    Grafana auth      Requires GF_SECURITY_ADMIN_USER/GF_SECURITY_ADMIN_PASSWORD.
+                      Optional anonymous access via DAO_TREASURY_GRAFANA_ANON_ENABLED=true.
 """
 
 import asyncio
@@ -30,6 +33,7 @@ from argparse import ArgumentParser
 from typing import Final, final
 
 from yearn_treasury import yteams
+from yearn_treasury._grafana import require_grafana_admin_env
 
 parser = ArgumentParser(description="Treasury CLI")
 subparsers = parser.add_subparsers(dest="command", required=True)
@@ -155,6 +159,9 @@ def main() -> None:
     os.environ["DAO_TREASURY_GRAFANA_PORT"] = str(Args.grafana_port)
     os.environ["DAO_TREASURY_RENDERER_PORT"] = str(Args.renderer_port)
     os.environ["VICTORIA_PORT"] = str(Args.victoria_port)
+
+    # Ensure Grafana admin credentials are provided before starting containers.
+    require_grafana_admin_env()
 
     async def yearn_wrapper():
         """


### PR DESCRIPTION
## Summary
Require Grafana admin credentials before starting Yearn Treasury exports, and align docs with the new default auth behavior.

## Changes
- Add Grafana env validation helper and enforce it before starting containers.
- Update CLI/doc examples to include required `GF_SECURITY_ADMIN_USER` / `GF_SECURITY_ADMIN_PASSWORD` and optional anonymous access.
- Add unit tests for Grafana env validation.

## Testing
- `pytest` (fails on Python 3.14: pytest 6.2.5 relies on `ast.Str`, which is removed)

## Risk and rollback
- Risk: startup now fails fast if Grafana admin env vars are missing.
- Rollback: revert this PR or provide the required env vars (optionally enable anonymous access via `DAO_TREASURY_GRAFANA_ANON_ENABLED=true`).